### PR TITLE
topic-1: Update augmenters to extract and apply event data (#2)

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -20,9 +20,9 @@ const trackerService = new TrackerService({
 });
 
 trackerService.init();
-trackerService.emit(Events.EVENT_A, { foo: 'bar' });
+trackerService.emit(Events.EVENT_A, { foo: 'bar', bar: 2 });
 trackerService.emit(Events.EVENT_AA, { foo: 'bar' });
-trackerService.emit(Events.EVENT_A, { foo: 'bar' });
+trackerService.emit(Events.EVENT_A, { foo: 'bar', bar: 10 });
 trackerService.emit(Events.EVENT_A, { foo: 'bar' });
 trackerService.emit(Events.EVENT_AA, { foo: 'bar' });
 trackerService.emit(Events.EVENT_AA, { foo: 'bar' });

--- a/src/trackers/tracker-a/handlers/handler-a.js
+++ b/src/trackers/tracker-a/handlers/handler-a.js
@@ -10,8 +10,8 @@ class HandlerA {
       { event: 'myEvent' },
       this.tracker.doSetup,
       this.tracker.doAugment(data)([
-        this.tracker.augmenters.addBar,
-        this.tracker.augmenters.addBaz,
+        this.tracker.augmenters.computeBar,
+        this.tracker.augmenters.computeBaz,
       ]),
       this.tracker.doLink,
       this.tracker.doLog
@@ -23,7 +23,7 @@ class HandlerA {
       { event: 'myAAEvent' },
       this.tracker.doSetup,
       this.tracker.doAugment(data)([
-        this.tracker.augmenters.addQuux,
+        this.tracker.augmenters.computeQuux,
       ]),
       this.tracker.doLink,
       this.tracker.doLog

--- a/src/trackers/tracker-a/tracker-a.js
+++ b/src/trackers/tracker-a/tracker-a.js
@@ -5,6 +5,15 @@ class TrackerA {
     return 10;
   }
 
+  get DEFAULTS() {
+    return {
+      FOO: 1,
+      BAR: 2,
+      BAZ: 3,
+      QUUX: 4,
+    };
+  }
+
   constructor(service, opts = {}) {
     this.log = [];
     this.service = service;
@@ -19,9 +28,9 @@ class TrackerA {
 
     // TEMP: Expose augmentors.
     this.augmenters = {
-      addBar: this.addBar,
-      addBaz: this.addBaz,
-      addQuux: this.addQuux,
+      computeBar: this.computeBar.bind(this),
+      computeBaz: this.computeBaz.bind(this),
+      computeQuux: this.computeQuux.bind(this),
     };
 
     // Bind.
@@ -40,7 +49,7 @@ class TrackerA {
     };
   }
 
-  doAugment(data) {
+  doAugment(data = {}) {
     return (augmenters = []) => (payload) => {
       return {
         ...payload,
@@ -58,15 +67,16 @@ class TrackerA {
     this.log = [payload, ...this.log].slice(0, this.opts.maxLogLength || TrackerA.MAX_LOG_LENGTH);
   }
 
-  addBar(data) {
-    return { bar: 'baz' };
+  computeBar(data = {}) {
+    const defaultBar = this.DEFAULTS.BAR;
+    return { bar: +data.bar ? defaultBar + (+data.bar) : defaultBar };
   }
 
-  addBaz(data) {
+  computeBaz(data = {}) {
     return { baz: 'quux' };
   }
 
-  addQuux(data) {
+  computeQuux(data = {}) {
     return { quux: 'foo' };
   }
 }

--- a/test/unit/trackers/tracker-a/handlers/handler-a.test.js
+++ b/test/unit/trackers/tracker-a/handlers/handler-a.test.js
@@ -43,9 +43,9 @@ describe('HandlerA', () => {
         doLink,
         doLog,
         augmenters: {
-          addBar: noop,
-          addBaz: noop,
-          addQuux: noop,
+          computeBar: noop,
+          computeBaz: noop,
+          computeQuux: noop,
         },
       });
     });
@@ -90,12 +90,12 @@ describe('HandlerA', () => {
 
       it('should invoke the function returned by `doAugment` with the correct augmenters', () => {
         const {
-          addBar,
-          addBaz,
+          computeBar,
+          computeBaz,
         } = handlerA.tracker.augmenters;
         handlerA.handleEventA();
 
-        expect(b).to.be.calledWithExactly([addBar, addBaz]);
+        expect(b).to.be.calledWithExactly([computeBar, computeBaz]);
       });
     });
 
@@ -139,11 +139,11 @@ describe('HandlerA', () => {
 
       it('should invoke the function returned by `doAugment` with the correct augmenters', () => {
         const {
-          addQuux,
+          computeQuux,
         } = handlerA.tracker.augmenters;
         handlerA.handleEventAA();
 
-        expect(b).to.be.calledWithExactly([addQuux]);
+        expect(b).to.be.calledWithExactly([computeQuux]);
       });
     });
   });

--- a/test/unit/trackers/tracker-a/tracker-a.test.js
+++ b/test/unit/trackers/tracker-a/tracker-a.test.js
@@ -188,7 +188,7 @@ describe('TrackerA', () => {
     });
 
     describe('doLog()', () => {
-      it('should add the payload to the `log`', () => {
+      it('should compute the payload to the `log`', () => {
         const payload = { foo: 'bar' };
 
         trackerA.doLog(payload);
@@ -231,27 +231,53 @@ describe('TrackerA', () => {
       });
     });
 
-    describe('addBar()', () => {
-      it('should return an object of the form: `{ bar: "baz" }`', () => {
-        expect(trackerA.addBar()).to.eql({ bar: 'baz' });
+    describe('computeBar()', () => {
+      it('should extract and apply `bar` from the data', () => {
+        const bar = 2;
+        const data = { bar };
+        expect(trackerA.computeBar(data)).to.eql({
+          bar: trackerA.DEFAULTS.BAR + bar,
+        });
+      });
+
+      it('should apply the default value for `bar`', () => {
+        expect(trackerA.computeBar()).to.eql({ bar: trackerA.DEFAULTS.BAR });
       });
     });
 
-    describe('addBaz()', () => {
+    describe('computeBaz()', () => {
       it('should return an object of the form: `{ baz: "quux" }`', () => {
-        expect(trackerA.addBaz()).to.eql({ baz: 'quux' });
+        expect(trackerA.computeBaz()).to.eql({ baz: 'quux' });
       });
     });
 
-    describe('addQuux()', () => {
+    describe('computeQuux()', () => {
       it('should return an object of the form: `{ quux: "foo" }`', () => {
-        expect(trackerA.addQuux()).to.eql({ quux: 'foo' });
+        expect(trackerA.computeQuux()).to.eql({ quux: 'foo' });
 
       });
     });
   });
 
   describe('Instance properties', () => {
+    let trackerA;
+
+    beforeEach(() => {
+      trackerA = new TrackerA();
+    });
+
+    describe('DEFAULTS', () => {
+      it('should be an object', () => {
+        expect(trackerA.DEFAULTS).to.be.a('object');
+      });
+
+      it('should contain defaults for: FOO; BAR; BAZ; QUUX', () => {
+        expect(trackerA.DEFAULTS.FOO).to.eq(1);
+        expect(trackerA.DEFAULTS.BAR).to.eq(2);
+        expect(trackerA.DEFAULTS.BAZ).to.eq(3);
+        expect(trackerA.DEFAULTS.QUUX).to.eq(4);
+      });
+    });
   });
 });
 


### PR DESCRIPTION
* Convert add*() utility methods to compute*()

* Update TrackerA to expose DEFAULTS via instance getter

* Update computeBar() to extract data from event payload

* Update method call signatures to include default values

* Bind TrackerA augmenters to ensure execution context

* Update sample data in demo